### PR TITLE
Add the management of the hooks

### DIFF
--- a/examples/01-basic/main.js
+++ b/examples/01-basic/main.js
@@ -1,4 +1,4 @@
-const fs = require('fs')
+// const fs = require('fs')
 const path = require('path')
 const routes = require('./routes')
 const middlewares = require('./middlewares')
@@ -20,5 +20,5 @@ const options = {
 }
 
 const cherry = new Cherry()
-cherry.configure(routes, middlewares, options)
+cherry.configure(routes, middlewares, [], options)
 cherry.start(options)

--- a/examples/01-basic/routes.js
+++ b/examples/01-basic/routes.js
@@ -6,7 +6,7 @@ module.exports = [
       console.log('body :', req.body)
       console.log('route param :', req.routeParameters)
       console.log('route :', req._route)
-      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.writeHead(200, { 'Content-Type': 'text/html' })
       res.end('<div>ROOT page</div>')
     },
     middlewares: [ 'midOne', 'midThree' ]

--- a/examples/02-multiple-response-type/main.js
+++ b/examples/02-multiple-response-type/main.js
@@ -9,11 +9,11 @@ const options = {
     res.writeHead(404)
     res.end('An error occured')
   },
-  httpPort: 4001
+  httpPort: 4003
 }
 
 const cherry = new Cherry()
-cherry.configure(routes, [], options)
+cherry.configure(routes, [], [], options)
 cherry.registerPlugin(CherryHandlebarsConnector)
 // cherry.registerPlugin(CherryPugConnector)
 cherry.start(options)

--- a/examples/03-hooks/HookExampleController.js
+++ b/examples/03-hooks/HookExampleController.js
@@ -1,0 +1,7 @@
+module.exports = {
+  demo: (req, res) => {
+    return {
+      foo: 'bar'
+    }
+  }
+}

--- a/examples/03-hooks/hooks.js
+++ b/examples/03-hooks/hooks.js
@@ -1,0 +1,50 @@
+const hookTypes = require('../../src/hooks/constants')
+
+module.exports = [
+  {
+    name: 'hook1-beforeStart',
+    priority: 1,
+    type: hookTypes.HOOK_BEFORE_START_SERVER,
+    method: (datas) => {
+      console.log('First hook before the start of the http(s) server, here are the datas')
+      console.log(datas)
+    }
+  },
+  {
+    name: 'hook2-afterStart',
+    priority: 1,
+    type: hookTypes.HOOK_AFTER_START_SERVER,
+    method: (datas) => {
+      console.log('Second hook after the start of the http(s) server, here are the datas')
+      console.log(datas)
+    }
+  },
+  {
+    name: 'hook3-beforeProcess',
+    priority: 1,
+    type: hookTypes.HOOK_BEFORE_PROCESS,
+    method: (datas) => {
+      console.log('Third hook before the process of a route, here are the datas')
+      console.log(datas)
+    }
+  },
+  {
+    name: 'hook4-afterProcess',
+    // Priority commented to show what happens if it's missing
+    // priority: 1,
+    type: hookTypes.HOOK_AFTER_PROCESS,
+    method: (datas) => {
+      console.log('Fourth hook after the process of a route, here are the datas')
+      console.log(datas)
+    }
+  },
+  {
+    name: 'hook5-afterProcess',
+    priority: 42,
+    type: hookTypes.HOOK_AFTER_PROCESS,
+    method: (datas) => {
+      console.log('Fifth hook after the process of a route, should be after the Hook 4 thanks to the priority, here are the datas')
+      console.log(datas)
+    }
+  }
+]

--- a/examples/03-hooks/main.js
+++ b/examples/03-hooks/main.js
@@ -1,0 +1,16 @@
+const routes = require('./routes')
+const hooks = require('./hooks')
+const Cherry = require('../../src/cherry')
+
+const options = {
+  onError: (req, res, e) => {
+    console.log(e)
+    res.writeHead(404)
+    res.end('An error occured')
+  },
+  httpPort: 4004
+}
+
+const cherry = new Cherry()
+cherry.configure(routes, [], hooks, options)
+cherry.start(options)

--- a/examples/03-hooks/routes.js
+++ b/examples/03-hooks/routes.js
@@ -1,0 +1,9 @@
+const HookExampleController = require('./HookExampleController')
+
+module.exports = [
+  {
+    method: ['GET'],
+    path: '/demo',
+    callback: HookExampleController.demo
+  }
+]

--- a/src/cherry.js
+++ b/src/cherry.js
@@ -1,7 +1,9 @@
 const Server = require('./server/server')
 const Dispatcher = require('./server/Dispatcher')
+const HookManager = require('./hooks/HookManager')
 const Route = require('./routes/Route')
 const check = require('./helpers/check')
+const { HOOK_BEFORE_START_SERVER, HOOK_AFTER_START_SERVER } = require('./hooks/constants')
 
 class Cherry {
   constructor () {
@@ -12,15 +14,17 @@ class Cherry {
     this.plugins = {
       ViewEngine: null
     }
+    this.hookManager = new HookManager()
   }
 
-  configure (routes, middlewares, options = {}) {
+  configure (routes, middlewares, hooks, options = {}) {
     let servers = null
 
     if (check.isDefined(options, 'onError')) {
       this.dispatcher.onError(options.onError)
     }
 
+    // configure the routes
     routes.forEach((route) => {
       if (route instanceof Route) {
         this.dispatcher.addRoute(route)
@@ -28,6 +32,14 @@ class Cherry {
         this.dispatcher.addRoute(new Route(route))
       }
     })
+
+    // configure the hooks
+    hooks.forEach((hook) => {
+      this.hookManager.addHook(hook)
+    })
+    this.hookManager.sortByPriorities()
+
+    // configure the middlewares
     middlewares.forEach((middleware) => {
       this.dispatcher.addMiddleware(middleware)
     })
@@ -38,13 +50,30 @@ class Cherry {
   }
 
   start (options) {
+    // Refacto the both block below (this is the same things with 2 different values)
     if (typeof this.http !== 'undefined' && this.http) {
       console.log(`Starting the http server on the port : ${options.httpPort}`)
+      this.hookManager.resolve(HOOK_BEFORE_START_SERVER, {
+        cherry: this,
+        server: this.http
+      })
       this.http.listen(options.httpPort)
+      this.hookManager.resolve(HOOK_AFTER_START_SERVER, {
+        cherry: this,
+        server: this.http
+      })
     }
     if (typeof this.https !== 'undefined' && this.https) {
       console.log(`Starting the https server on the port : ${options.httpsPort}`)
+      this.hookManager.resolve(HOOK_BEFORE_START_SERVER, {
+        cherry: this,
+        server: this.https
+      })
       this.https.listen(options.httpsPort)
+      this.hookManager.resolve(HOOK_AFTER_START_SERVER, {
+        cherry: this,
+        server: this.https
+      })
     }
   }
 

--- a/src/hooks/Hook.js
+++ b/src/hooks/Hook.js
@@ -1,0 +1,59 @@
+const check = require('../helpers/check')
+const HookException = require('./HookException')
+
+class Hook {
+  constructor (hook) {
+    if (!check.isDefined(hook, 'name') && typeof hook.name === 'string') {
+      throw new HookException('name')
+    }
+    if (!check.isDefined(hook, 'method') && typeof hook.method === 'function') {
+      throw new HookException('method')
+    }
+    if (!check.isDefined(hook, 'type') && typeof hook.type === 'string') {
+      throw new HookException('type')
+    }
+    if (check.isDefined(hook, 'priority')) {
+      this.priority = hook.priority
+    } else {
+      console.warn('Missing priority in the Hook, set to 1 by default')
+      this.priority = 1
+    }
+    this.name = hook.name
+    this.type = hook.type
+    this.method = hook.method
+  }
+
+  /**
+   * Retrieve the name of a hook
+   * @return {string}
+   */
+  getName () {
+    return this.name
+  }
+
+  /**
+   * Retrieve the type of a hook
+   * @return {string}
+   */
+  getType () {
+    return this.type
+  }
+
+  /**
+   * Retrieve the priority of a hook
+   * @return {integer}
+   */
+  getPriority () {
+    return this.priority
+  }
+
+  /**
+   * Execute the process of the hook
+   * @param {mixed} datas The data passed to the hook
+   */
+  execute (datas) {
+    this.method(datas)
+  }
+}
+
+module.exports = Hook

--- a/src/hooks/HookException.js
+++ b/src/hooks/HookException.js
@@ -1,0 +1,8 @@
+class HookException extends Error {
+  constructor (option) {
+    super(`An error occured : The option '${option}' is missing or invalid in the hook definition`)
+    this.option = option
+  }
+}
+
+module.exports = HookException

--- a/src/hooks/HookManager.js
+++ b/src/hooks/HookManager.js
@@ -1,0 +1,42 @@
+const Hook = require('./Hook')
+
+class HookManager {
+  constructor () {
+    this.hooks = []
+  }
+
+  /**
+   * Sort the hooks by priorities
+   */
+  addHook (hook) {
+    let _hook = hook
+    if (!(hook instanceof Hook)) {
+      _hook = new Hook(hook)
+    }
+    this.hooks.push(_hook)
+  }
+
+  /**
+   * Sort the hooks by priorities
+   */
+  sortByPriorities () {
+    this.hooks.sort((hookA, hookB) => {
+      return hookA.getPriority() < hookB.getPriority()
+    })
+  }
+
+  /**
+   * Executes the matching hooks based on a hook type
+   * @param {string} hookType The type of hook we want to resolve
+   * @param {mixed} datas The data passed to the hook
+   */
+  resolve (hookType, datas) {
+    this.hooks.forEach((hook) => {
+      if (hook.getType() === hookType) {
+        hook.execute(datas)
+      }
+    })
+  }
+}
+
+module.exports = HookManager

--- a/src/hooks/constants.js
+++ b/src/hooks/constants.js
@@ -1,0 +1,6 @@
+module.exports = {
+  HOOK_BEFORE_START_SERVER: 'beforeStart',
+  HOOK_AFTER_START_SERVER: 'afterStart',
+  HOOK_BEFORE_PROCESS: 'beforeProcess',
+  HOOK_AFTER_PROCESS: 'afterProcess'
+}


### PR DESCRIPTION
Cherry provides for the moment 4 hooks :
- beforeStart : Before the start of the server
- afterStart : After the start of the server
- beforeProcess : Before the execution of the middleware/callback of a route
- afterProcess : After the execution of the middleware/callback of a route

Issue : https://github.com/Lund-Org/cherry/issues/6